### PR TITLE
core: healthd: allow custom charger res

### DIFF
--- a/healthd/Android.mk
+++ b/healthd/Android.mk
@@ -64,8 +64,13 @@ endef
 
 _img_modules :=
 _images :=
+ifneq ($(BOARD_CHARGER_IMG_PATH),)
+$(foreach _img, $(call find-subdir-subdir-files, ../../../$(BOARD_CHARGER_IMG_PATH), "*.png"), \
+  $(eval $(call _add-charger-image,$(_img))))
+else
 $(foreach _img, $(call find-subdir-subdir-files, "images", "*.png"), \
   $(eval $(call _add-charger-image,$(_img))))
+endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := charger_res_images


### PR DESCRIPTION
Example: BOARD_CHARGER_IMG_PATH := device/samsung/galaxys2/res/charger

Android 5.0:
system/core/charger now moved to system/core/healthd

Signed-off-by: Andreas Blaesius <skate4life@gmx.de>
Change-Id: I4df55dbf439c739ce98adc373b2074a982fbe0d7